### PR TITLE
Remove first and last name requirement for reverse proxy creation

### DIFF
--- a/revers_proxyReadMe.txt
+++ b/revers_proxyReadMe.txt
@@ -4,14 +4,14 @@ Before using the 210 reverse proxy server script,
 create a csv file with a student's first name, last name, netID and IP address.
 For example:
 
-First,Last,netID,IP_addr
-Jane,Doe,jd123,192.168.x.x
-Moe,Joe,mj321,192.168.x.x
+netID,IP_addr
+jd123,192.168.x.x
+mj321,192.168.x.x
 
 The script handles the first row as column names,
 so make sure the first line of the csv file is:
 
-First,Last,netID,IP_addr
+netID,IP_addr
 
 Save the csv as 'isp.csv' in the same file folder as the 210liveservers.py.
 

--- a/reverse_proxy_setup.py
+++ b/reverse_proxy_setup.py
@@ -27,8 +27,7 @@ with open('ips.csv') as csvfile:
                 ip_addr = row['IP_addr']
                 file_write.write("#Http Server\nserver{\n\tlisten 80;\n\tserver_name " + netID + ".it210.it.et.byu.edu;\n\tlocation / {\n\t\tproxy_pass http://" + ip_addr + ";\n\t\tinclude include.d/nocacheproxy.conf;\n\t}\n}\n")
                 file_write.write("#NodeJS Server\nserver{\n\tlisten 80;\n\tserver_name nodejs." + netID + ".it210.it.et.byu.edu;\n\tlocation / {\n\t\tproxy_pass http://" + ip_addr + ":1337;\n\t\tinclude include.d/nocacheproxy.conf;\n\t}\n}\n\n")
-                #This will print out the name of the student to make sure they were added
-                print(name + " added successfully!")
+                
                 line_count += 1
 #This statement lets you know how many students were added successfuly.
 print ('{} students have reverse proxy servers'.format(line_count))

--- a/reverse_proxy_setup.py
+++ b/reverse_proxy_setup.py
@@ -21,12 +21,10 @@ with open('ips.csv') as csvfile:
         for row in reader:
                 print(row)
                 #This gets the student's full name
-                name = row['First'] + " " + row['Last']
                 #This gets the student's Net ID
                 netID = row['netID']
                 #This gets the student's assigned IP Address
                 ip_addr = row['IP_addr']
-                file_write.write("#" + name + "\n")
                 file_write.write("#Http Server\nserver{\n\tlisten 80;\n\tserver_name " + netID + ".it210.it.et.byu.edu;\n\tlocation / {\n\t\tproxy_pass http://" + ip_addr + ";\n\t\tinclude include.d/nocacheproxy.conf;\n\t}\n}\n")
                 file_write.write("#NodeJS Server\nserver{\n\tlisten 80;\n\tserver_name nodejs." + netID + ".it210.it.et.byu.edu;\n\tlocation / {\n\t\tproxy_pass http://" + ip_addr + ":1337;\n\t\tinclude include.d/nocacheproxy.conf;\n\t}\n}\n\n")
                 #This will print out the name of the student to make sure they were added


### PR DESCRIPTION
Creating the csv for the script is significantly less complicated if there is no requirement for a first and last name with each entry.